### PR TITLE
Image load can fall back to Flutter assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 .svn/
 
 # IntelliJ related
-*.iml
 *.ipr
 *.iws
 .idea/
@@ -41,6 +40,8 @@ lcov.info
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
+**/android/.project
+**/android/.settings/org.eclipse.buildship.core.prefs
 
 # iOS/XCode related
 **/ios/**/*.mode1v3

--- a/ios/Classes/ArkitPlugin.h
+++ b/ios/Classes/ArkitPlugin.h
@@ -1,4 +1,5 @@
 #import <Flutter/Flutter.h>
 
 @interface ArkitPlugin : NSObject<FlutterPlugin>
+@property (class, nonatomic) NSObject<FlutterPluginRegistrar> *registrar;
 @end

--- a/ios/Classes/ArkitPlugin.m
+++ b/ios/Classes/ArkitPlugin.m
@@ -2,10 +2,23 @@
 #import "FlutterArkit.h"
 
 @implementation ArkitPlugin
+NSObject<FlutterPluginRegistrar> *_registrar;
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  self.registrar = registrar;
   FlutterArkitFactory* arkitFactory =
       [[FlutterArkitFactory alloc] initWithMessenger:registrar.messenger];
   [registrar registerViewFactory:arkitFactory withId:@"arkit"];
+}
+
++ (NSObject<FlutterPluginRegistrar> *)registrar {
+    return _registrar;
+}
+
++ (void)setRegistrar:(NSObject<FlutterPluginRegistrar> *)newRegistrar {
+    if (newRegistrar != _registrar) {
+        _registrar = newRegistrar;
+    }
 }
 
 @end

--- a/ios/Classes/GeometryBuilder.m
+++ b/ios/Classes/GeometryBuilder.m
@@ -1,4 +1,5 @@
 #import "GeometryBuilder.h"
+#import "ArkitPlugin.h"
 #import "Color.h"
 #import "DecodableUtils.h"
 
@@ -87,6 +88,14 @@
 + (id) getMaterialProperty: (NSDictionary*) propertyString {
     if (propertyString[@"image"] != nil) {
         UIImage* img = [UIImage imageNamed:propertyString[@"image"]];
+        
+        if(img == nil)
+        {
+            NSString* asset_path = [@"assets/images/" stringByAppendingString:propertyString[@"image"]];
+            NSString* path = [[NSBundle mainBundle] pathForResource:[[ArkitPlugin registrar] lookupKeyForAsset:asset_path] ofType:nil];
+            img = [UIImage imageNamed: path];
+        }
+        
         return img;
         
     } else if (propertyString[@"color"] != nil) {


### PR DESCRIPTION
Images to be used by geometries can now be stored in the Flutter application in addition to the default location(directly in Runner).

_GeometryBuilder.getMaterialProperty()_ will check the default location for the provided file. If it is not found, **/assets/images/** will be checked.

Detailed Changelog:
- Added  _registrar_ property directly to the _ArkitPlugin_ for access to bundle files (with associated setter and getter).
- Set the _registrar_ property in _ArkitPlugin.registerWithRegistrar()_.
- Added fallback logic to _GeometryBuilder.getMaterialProperty()_ that uses the registrar to check Flutter assets stored in **/assets/images/**. 